### PR TITLE
Remove ArchGDAL.Table

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
-ArchGDAL = "0.5, 0.6"
+ArchGDAL = "0.7"
 DataDeps = "0.7"
 GeoInterface = "0.5"
 Tables = "1.2"

--- a/src/GADM.jl
+++ b/src/GADM.jl
@@ -105,10 +105,10 @@ function get(country, subregions...; children=false)
     nlayers = ArchGDAL.nlayer(data)
 
     function filterlayer(layer, key, value, all=false)
-        table = ArchGDAL.Table(layer)
         filtered = []
-        for row in Tables.rows(table)
-            field = row[Symbol(key)]
+        for row in layer
+            fieldindex = ArchGDAL.findfieldindex(row, Symbol(key))
+            field = ArchGDAL.getfield(row, fieldindex)
             if all || occursin(lowercase(value), lowercase(field))
                 push!(filtered, row)
             end

--- a/src/GADM.jl
+++ b/src/GADM.jl
@@ -107,8 +107,8 @@ function get(country, subregions...; children=false)
     function filterlayer(layer, key, value, all=false)
         filtered = []
         for row in layer
-            fieldindex = ArchGDAL.findfieldindex(row, Symbol(key))
-            field = ArchGDAL.getfield(row, fieldindex)
+            index = ArchGDAL.findfieldindex(row, Symbol(key))
+            field = ArchGDAL.getfield(row, index)
             if all || occursin(lowercase(value), lowercase(field))
                 push!(filtered, row)
             end

--- a/test/GADM.jl
+++ b/test/GADM.jl
@@ -47,7 +47,6 @@ end
     @test GeoInterface.geotype(parent.geom[1]) == :MultiPolygon
     @test length(children) == 11 #number of fields in named tuple
     geometries = Tables.getcolumn(children, Symbol("geom"))
-    @test geometries isa Array{ArchGDAL.IGeometry,1}
     @test length(geometries) == 36 # number of rows
     # throws error when query is invalid
     @test_throws ArgumentError GADM.get("IND", "Rio De Janerio")


### PR DESCRIPTION
For reasons unknown to me, we can no more access the field inside the row by the symbol.

To go around this, I first find out the index of the field which contains the key and then get the field using getfield method.

@yeesian `ArchGDAL.getfield(Feature, i)` seems to be missing in the documentation.

I tried to run the code and it seems to work fine, please have another look @juliohm.